### PR TITLE
Refactor shared code and improve thread safety (sync > async calls)

### DIFF
--- a/Demo/Program.cs
+++ b/Demo/Program.cs
@@ -22,7 +22,6 @@ namespace Demo
             var databaseName = "db1";
 
             // write
-            AzureBlockBlobStream.WriteDebugLogs = true;
             using (var stream = new AzureBlockBlobStream(connectionString, databaseName))
                 TestWriteDatabase(stream);
 
@@ -44,7 +43,6 @@ namespace Demo
             var databaseName = "db1";
 
             // write
-            AzurePageBlobStream.WriteDebugLogs = true;
             using (var stream = new AzurePageBlobStream(connectionString, databaseName))
                 TestWriteDatabase(stream);
 

--- a/LiteDB.AzureBlob/Consts.cs
+++ b/LiteDB.AzureBlob/Consts.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.Azure.Storage.Blob;
+
+namespace LiteDB.AzureBlob
+{
+    static class Consts
+    {
+        internal static int PageSize = 1024 * 8;  // Default PageSize of LiteDB 5
+        internal static int Pages = 8;
+        internal static string DefaultContainerName = "litedbs";
+        internal static long DefaultStreamSize = 1024 * 1024 * 1024; //1G
+        internal static PremiumPageBlobTier DefaultBlobTier = PremiumPageBlobTier.P4;
+        internal const string MetadataLengthKey = "STREAM_LENGTH";
+        internal const int NumberOfLocks = 111;  // should be more than enough
+    }
+}

--- a/LiteDB.AzureBlob/TaskExtensions.cs
+++ b/LiteDB.AzureBlob/TaskExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading.Tasks;
+
+namespace LiteDB.AzureBlob
+{
+    internal static class TaskExtensions
+    {
+        internal static T SyncResult<T>(this Task<T> task)
+            => task != null ? task.ConfigureAwait(false).GetAwaiter().GetResult() : default(T);
+
+        internal static void SyncWait(this Task task)
+            => task?.ConfigureAwait(false).GetAwaiter().GetResult();
+    }
+}


### PR DESCRIPTION
Share common constants for Page/Block streams

ConfigureAwait(false).GetAwaiter().GetResult() for all blocking async calls in sync methods to avoid deadlocks when scheduler is in use (e.g. asp.net)